### PR TITLE
fixed restoring forces formulation

### DIFF
--- a/src/hydrodynamics.cpp
+++ b/src/hydrodynamics.cpp
@@ -155,8 +155,10 @@ Eigen::Vector6d RestoringForces::calculateRestoringForcesVector(const Eigen::Mat
 
   Eigen::Vector6d g_rb;
 
-  g_rb.topRows(3) = rot.transpose() * (fg + fb);
-  g_rb.bottomRows(3) = center_of_gravity_.cross(rot.transpose() * fg) + center_of_buoyancy_.cross(rot.transpose() * fb);
+  const Eigen::Matrix3d rot_t = rot.transpose();
+
+  g_rb.topRows(3) = rot_t * (fg + fb);
+  g_rb.bottomRows(3) = center_of_gravity_.cross(rot_t * fg) + center_of_buoyancy_.cross(rot_t * fb);
 
   g_rb *= -1;
 

--- a/src/hydrodynamics.cpp
+++ b/src/hydrodynamics.cpp
@@ -155,8 +155,8 @@ Eigen::Vector6d RestoringForces::calculateRestoringForcesVector(const Eigen::Mat
 
   Eigen::Vector6d g_rb;
 
-  g_rb.topRows(3) = rot * (fg + fb);
-  g_rb.bottomRows(3) = center_of_gravity_.cross(rot * fg) + center_of_buoyancy_.cross(rot * fb);
+  g_rb.topRows(3) = rot.transpose() * (fg + fb);
+  g_rb.bottomRows(3) = center_of_gravity_.cross(rot.transpose() * fg) + center_of_buoyancy_.cross(rot.transpose() * fb);
 
   g_rb *= -1;
 


### PR DESCRIPTION
## Changes Made

The rotation matrix `rot` is now transposed before being applied to the force vectors `fg` and `fb`, ensuring correct force calculations as per guidelines in Thor Fossen's Handbook of Marine Craft.

## Associated Issues

- Fixes # (issue)