### PR TITLE
Revert changes to CMakeLists file to support backwards compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
-  "name": "ROS 2 NVIDIA Dev Container",
+  "name": "Dev Container",
   "dockerFile": "Dockerfile",
   "context": "../",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/ubuntu/ws_ros/src/auv_controllers,type=bind",
-  "workspaceFolder": "/home/ubuntu/ws_ros/src/auv_controllers",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/ubuntu/ws_ros/src/hydrodynamics,type=bind",
+  "workspaceFolder": "/home/ubuntu/ws_ros/src/hydrodynamics",
   "remoteUser": "ubuntu",
   "customizations": {
     "vscode": {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,19 @@ add_library(hydrodynamics SHARED)
 target_sources(hydrodynamics
   PRIVATE
     src/hydrodynamics.cpp
-  PUBLIC
-    FILE_SET HEADERS
-    BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
-    FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/hydrodynamics/hydrodynamics.hpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/hydrodynamics/eigen.hpp
 )
-
+target_include_directories(hydrodynamics
+  PUBLIC
+    $<INSTALL_INTERFACE:include/hydrodynamics>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
 target_compile_features(hydrodynamics PUBLIC cxx_std_20)
 target_link_libraries(hydrodynamics Eigen3::Eigen)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/hydrodynamics
+)
 
 install(
   TARGETS hydrodynamics
@@ -30,7 +33,6 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  FILE_SET HEADERS
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
## Changes Made

Introducing the `FILES_SET` from CMake 23 broke backwards compatibility with ROS 2 Iron and Humble, which both use CMake 22. Because I don't feel like maintaining multiple branches in this repo, I'm just going to revert back to the old syntax.