### PR TITLE
Modified construction of rigid body inertia and coriolis matrices

### DIFF
--- a/include/hydrodynamics/hydrodynamics.hpp
+++ b/include/hydrodynamics/hydrodynamics.hpp
@@ -46,7 +46,7 @@ struct Inertia
     double Kdp,
     double Mdq,
     double Ndr,
-    Eigen::Vector3d center_of_gravity);
+    const Eigen::Vector3d & center_of_gravity);
 
   /// Create a new wrapper for inertial parameters (including added mass and rigid body inertia) using:
   /// - the mass of the vehicle,
@@ -56,7 +56,7 @@ struct Inertia
     double mass,
     const Eigen::Vector3d & moments,
     const Eigen::Vector6d & added_mass,
-    Eigen::Vector3d center_of_gravity);
+    const Eigen::Vector3d & center_of_gravity);
 
   Eigen::Matrix6d rigid_body_matrix;
   Eigen::Matrix6d added_mass_matrix;

--- a/include/hydrodynamics/hydrodynamics.hpp
+++ b/include/hydrodynamics/hydrodynamics.hpp
@@ -61,7 +61,6 @@ struct Inertia
   Eigen::Matrix6d rigid_body_matrix;
   Eigen::Matrix6d added_mass_matrix;
   Eigen::Matrix6d mass_matrix;
-  Eigen::Vector3d center_of_gravity;
 };
 
 struct Coriolis

--- a/include/hydrodynamics/hydrodynamics.hpp
+++ b/include/hydrodynamics/hydrodynamics.hpp
@@ -45,17 +45,23 @@ struct Inertia
     double Zdw,
     double Kdp,
     double Mdq,
-    double Ndr);
+    double Ndr,
+    Eigen::Vector3d center_of_gravity);
 
   /// Create a new wrapper for inertial parameters (including added mass and rigid body inertia) using:
   /// - the mass of the vehicle,
   /// - the moments of inertia about the x, y, and z axes,
   /// - the added mass coefficients in the surge, sway, heave, roll, pitch, and yaw directions.
-  Inertia(double mass, const Eigen::Vector3d & moments, const Eigen::Vector6d & added_mass);
+  Inertia(
+    double mass,
+    const Eigen::Vector3d & moments,
+    const Eigen::Vector6d & added_mass,
+    Eigen::Vector3d center_of_gravity);
 
   Eigen::Matrix6d rigid_body_matrix;
   Eigen::Matrix6d added_mass_matrix;
   Eigen::Matrix6d mass_matrix;
+  Eigen::Vector3d center_of_gravity;
 };
 
 struct Coriolis
@@ -76,13 +82,14 @@ struct Coriolis
     double Zdw,
     double Kdp,
     double Mdq,
-    double Ndr);
+    double Ndr,
+    Eigen::Vector3d center_of_gravity);
 
   /// Create a new wrapper for the Coriolis and centripetal force parameters using:
   /// - the mass of the vehicle,
   /// - the moments of inertia about the x, y, and z axes,
   /// - the added mass coefficients in the surge, sway, heave, roll, pitch, and yaw directions.
-  Coriolis(double mass, const Eigen::Vector3d & moments, Eigen::Vector6d added_mass);
+  Coriolis(double mass, const Eigen::Vector3d & moments, Eigen::Vector6d added_mass, Eigen::Vector3d center_of_gravity);
 
   /// Calculate the rigid body Coriolis matrix using the angular velocity of the vehicle.
   [[nodiscard]] auto calculate_rigid_body_coriolis_matrix(const Eigen::Vector3d & angular_velocity) const
@@ -97,6 +104,7 @@ struct Coriolis
   double mass;
   Eigen::Matrix3d moments;
   Eigen::Vector6d added_mass_coeff;
+  Eigen::Vector3d center_of_gravity;
 };
 
 struct Damping

--- a/include/hydrodynamics/hydrodynamics.hpp
+++ b/include/hydrodynamics/hydrodynamics.hpp
@@ -45,13 +45,19 @@ struct Inertia
     double Zdw,
     double Kdp,
     double Mdq,
-    double Ndr,
-    const Eigen::Vector3d & center_of_gravity);
+    double Ndr);
 
   /// Create a new wrapper for inertial parameters (including added mass and rigid body inertia) using:
   /// - the mass of the vehicle,
   /// - the moments of inertia about the x, y, and z axes,
   /// - the added mass coefficients in the surge, sway, heave, roll, pitch, and yaw directions.
+  Inertia(double mass, const Eigen::Vector3d & moments, const Eigen::Vector6d & added_mass);
+
+  /// Create a new wrapper for inertial parameters (including added mass and rigid body inertia) using:
+  /// - the mass of the vehicle,
+  /// - the moments of inertia about the x, y, and z axes,
+  /// - the added mass coefficients in the surge, sway, heave, roll, pitch, and yaw directions.
+  /// - the center of gravity of the vehicle.
   Inertia(
     double mass,
     const Eigen::Vector3d & moments,
@@ -81,13 +87,19 @@ struct Coriolis
     double Zdw,
     double Kdp,
     double Mdq,
-    double Ndr,
-    Eigen::Vector3d center_of_gravity);
+    double Ndr);
 
   /// Create a new wrapper for the Coriolis and centripetal force parameters using:
   /// - the mass of the vehicle,
   /// - the moments of inertia about the x, y, and z axes,
   /// - the added mass coefficients in the surge, sway, heave, roll, pitch, and yaw directions.
+  Coriolis(double mass, const Eigen::Vector3d & moments, Eigen::Vector6d added_mass);
+
+  /// Create a new wrapper for the Coriolis and centripetal force parameters using:
+  /// - the mass of the vehicle,
+  /// - the moments of inertia about the x, y, and z axes,
+  /// - the added mass coefficients in the surge, sway, heave, roll, pitch, and yaw directions.
+  /// - the center of gravity of the vehicle.
   Coriolis(double mass, const Eigen::Vector3d & moments, Eigen::Vector6d added_mass, Eigen::Vector3d center_of_gravity);
 
   /// Calculate the rigid body Coriolis matrix using the angular velocity of the vehicle.

--- a/src/hydrodynamics.cpp
+++ b/src/hydrodynamics.cpp
@@ -47,11 +47,14 @@ Inertia::Inertia(
   double Zdw,
   double Kdp,
   double Mdq,
-  double Ndr)
+  double Ndr,
+  Eigen::Vector3d center_of_gravity)
 {
   // Construct the rigid body inertia matrix
   rigid_body_matrix = Eigen::Matrix6d::Zero();
   rigid_body_matrix.topLeftCorner(3, 3) = mass * Eigen::Matrix3d::Identity();
+  rigid_body_matrix.topRightCorner(3, 3) = -mass * make_skew_symmetric_matrix(center_of_gravity);
+  rigid_body_matrix.bottomLeftCorner(3, 3) = mass * make_skew_symmetric_matrix(center_of_gravity);
   rigid_body_matrix.bottomRightCorner(3, 3) = Eigen::Vector3d(Ixx, Iyy, Izz).asDiagonal().toDenseMatrix();
 
   // Construct the added mass matrix
@@ -59,13 +62,22 @@ Inertia::Inertia(
 
   // The complete mass matrix is the sum of the rigid body and added mass matrices
   mass_matrix = rigid_body_matrix + added_mass_matrix;
+
+  // Set the center of gravity
+  this->center_of_gravity = std::move(center_of_gravity);
 }
 
-Inertia::Inertia(double mass, const Eigen::Vector3d & moments, const Eigen::Vector6d & added_mass)
+Inertia::Inertia(
+  double mass,
+  const Eigen::Vector3d & moments,
+  const Eigen::Vector6d & added_mass,
+  Eigen::Vector3d center_of_gravity)
 {
   // Construct the rigid body inertia matrix
   Eigen::Matrix6d rigid_body_matrix = Eigen::Matrix6d::Zero();
   rigid_body_matrix.topLeftCorner(3, 3) = mass * Eigen::Matrix3d::Identity();
+  rigid_body_matrix.topRightCorner(3, 3) = -mass * make_skew_symmetric_matrix(center_of_gravity);
+  rigid_body_matrix.bottomLeftCorner(3, 3) = mass * make_skew_symmetric_matrix(center_of_gravity);
   rigid_body_matrix.bottomRightCorner(3, 3) = moments.asDiagonal().toDenseMatrix();
 
   // Construct the added mass matrix
@@ -73,6 +85,9 @@ Inertia::Inertia(double mass, const Eigen::Vector3d & moments, const Eigen::Vect
 
   // The complete mass matrix is the sum of the rigid body and added mass matrices
   mass_matrix = rigid_body_matrix + added_mass_matrix;
+
+  // Set the center of gravity
+  this->center_of_gravity = std::move(center_of_gravity);
 }
 
 Coriolis::Coriolis(
@@ -85,17 +100,24 @@ Coriolis::Coriolis(
   double Zdw,
   double Kdp,
   double Mdq,
-  double Ndr)
+  double Ndr,
+  Eigen::Vector3d center_of_gravity)
 : mass(mass),
   moments(Eigen::Vector3d(Ixx, Iyy, Izz).asDiagonal().toDenseMatrix()),
-  added_mass_coeff(Eigen::Vector6d(Xdu, Ydv, Zdw, Kdp, Mdq, Ndr))
+  added_mass_coeff(Eigen::Vector6d(Xdu, Ydv, Zdw, Kdp, Mdq, Ndr)),
+  center_of_gravity(std::move(center_of_gravity))
 {
 }
 
-Coriolis::Coriolis(double mass, const Eigen::Vector3d & moments, Eigen::Vector6d added_mass)
+Coriolis::Coriolis(
+  double mass,
+  const Eigen::Vector3d & moments,
+  Eigen::Vector6d added_mass,
+  Eigen::Vector3d center_of_gravity)
 : mass(mass),
   moments(moments.asDiagonal().toDenseMatrix()),
-  added_mass_coeff(std::move(added_mass))
+  added_mass_coeff(std::move(added_mass)),
+  center_of_gravity(std::move(center_of_gravity))
 {
 }
 
@@ -106,6 +128,10 @@ auto Coriolis::calculate_rigid_body_coriolis_matrix(const Eigen::Vector3d & angu
   const Eigen::Vector3d moments_v2 = moments * angular_velocity;
 
   coriolis.topLeftCorner(3, 3) = mass * make_skew_symmetric_matrix(angular_velocity);
+  coriolis.topRightCorner(3, 3) =
+    -mass * make_skew_symmetric_matrix(angular_velocity) * make_skew_symmetric_matrix(center_of_gravity);
+  coriolis.bottomLeftCorner(3, 3) =
+    mass * make_skew_symmetric_matrix(center_of_gravity) * make_skew_symmetric_matrix(angular_velocity);
   coriolis.bottomRightCorner(3, 3) = -make_skew_symmetric_matrix(moments_v2);
 
   return coriolis;

--- a/src/hydrodynamics.cpp
+++ b/src/hydrodynamics.cpp
@@ -62,9 +62,6 @@ Inertia::Inertia(
 
   // The complete mass matrix is the sum of the rigid body and added mass matrices
   mass_matrix = rigid_body_matrix + added_mass_matrix;
-
-  // Set the center of gravity
-  this->center_of_gravity = std::move(center_of_gravity);
 }
 
 Inertia::Inertia(
@@ -85,9 +82,6 @@ Inertia::Inertia(
 
   // The complete mass matrix is the sum of the rigid body and added mass matrices
   mass_matrix = rigid_body_matrix + added_mass_matrix;
-
-  // Set the center of gravity
-  this->center_of_gravity = std::move(center_of_gravity);
 }
 
 Coriolis::Coriolis(

--- a/src/hydrodynamics.cpp
+++ b/src/hydrodynamics.cpp
@@ -108,16 +108,17 @@ Coriolis::Coriolis(
   double Ndr)
 : mass(mass),
   moments(Eigen::Vector3d(Ixx, Iyy, Izz).asDiagonal().toDenseMatrix()),
-  added_mass_coeff(Eigen::Vector6d(Xdu, Ydv, Zdw, Kdp, Mdq, Ndr))
+  added_mass_coeff(Eigen::Vector6d(Xdu, Ydv, Zdw, Kdp, Mdq, Ndr)),
+  center_of_gravity(Eigen::Vector3d::Zero())
 {
 }
 
 Coriolis::Coriolis(double mass, const Eigen::Vector3d & moments, Eigen::Vector6d added_mass)
 : mass(mass),
   moments(moments.asDiagonal().toDenseMatrix()),
-  added_mass_coeff(std::move(added_mass))
+  added_mass_coeff(std::move(added_mass)),
+  center_of_gravity(Eigen::Vector3d::Zero())
 {
-  center_of_gravity = Eigen::Vector3d::Zero();
 }
 
 Coriolis::Coriolis(

--- a/src/hydrodynamics.cpp
+++ b/src/hydrodynamics.cpp
@@ -48,7 +48,7 @@ Inertia::Inertia(
   double Kdp,
   double Mdq,
   double Ndr,
-  Eigen::Vector3d center_of_gravity)
+  const Eigen::Vector3d center_of_gravity)
 {
   // Construct the rigid body inertia matrix
   rigid_body_matrix = Eigen::Matrix6d::Zero();
@@ -68,7 +68,7 @@ Inertia::Inertia(
   double mass,
   const Eigen::Vector3d & moments,
   const Eigen::Vector6d & added_mass,
-  Eigen::Vector3d center_of_gravity)
+  const Eigen::Vector3d center_of_gravity)
 {
   // Construct the rigid body inertia matrix
   Eigen::Matrix6d rigid_body_matrix = Eigen::Matrix6d::Zero();

--- a/src/hydrodynamics.cpp
+++ b/src/hydrodynamics.cpp
@@ -48,7 +48,7 @@ Inertia::Inertia(
   double Kdp,
   double Mdq,
   double Ndr,
-  const Eigen::Vector3d center_of_gravity)
+  const Eigen::Vector3d & center_of_gravity)
 {
   // Construct the rigid body inertia matrix
   rigid_body_matrix = Eigen::Matrix6d::Zero();
@@ -68,7 +68,7 @@ Inertia::Inertia(
   double mass,
   const Eigen::Vector3d & moments,
   const Eigen::Vector6d & added_mass,
-  const Eigen::Vector3d center_of_gravity)
+  const Eigen::Vector3d & center_of_gravity)
 {
   // Construct the rigid body inertia matrix
   Eigen::Matrix6d rigid_body_matrix = Eigen::Matrix6d::Zero();


### PR DESCRIPTION
## Changes Made

Included the computation for the off-diagonal terms of the rigid body inertia and Coriolis matrices based on the equations presented in [1] and [2].

[1] Fossen, T.I., 2011. Handbook of marine craft hydrodynamics and motion control. John Willy & Sons Ltd.
[2] Antonelli, G., 2014. Underwater Robots, volume 96 of Springer Tracts in Advanced Robotics.
